### PR TITLE
Update data.py

### DIFF
--- a/uer/utils/data.py
+++ b/uer/utils/data.py
@@ -1067,6 +1067,7 @@ class ClsDataset(Dataset):
                     src_b = src_b + [self.vocab.get(SEP_TOKEN)]
 
                     src = src_a + src_b
+                    tgt = label
                     seg = [1] * len(src_a) + [2] * len(src_b)
 
                     if len(src) >= self.seq_length:


### PR DESCRIPTION
修复了使用precess.py单进程模式预处理文本对（len(line) == 3）分类（cls）时，tgt未定义的bug。
该bug同时导致了上述任务的多进程模式下，不报错，但是生成的持久化文件为空的问题